### PR TITLE
Allow building with Cabal-2.0

### DIFF
--- a/liquidhaskell-cabal.cabal
+++ b/liquidhaskell-cabal.cabal
@@ -3,7 +3,7 @@ version:               0.1.1.0
 synopsis:              Liquid Haskell integration for Cabal and Stack
 description:           Provides support for checking projects using Cabal
                        and/or stack with LiquidHaskell.
-                       
+
                        Please see the
                        <https://github.com/spinda/liquidhaskell-cabal/blob/0.1.1.0/README.md README>
                        on GitHub for setup and usage instructions.
@@ -22,7 +22,7 @@ library
   hs-source-dirs:      src
   exposed-modules:     LiquidHaskell.Cabal
   build-depends:       base >= 4.4 && < 5
-                     , Cabal >= 1.18 && < 1.26
+                     , Cabal >= 1.18 && < 2.1
                      , filepath >= 1.3 && <1.5
   default-language:    Haskell2010
 


### PR DESCRIPTION
Several API changes were introduced in `Cabal-2.0`, so this patches them up with CPP as required.